### PR TITLE
Add Node 10 (LTS) image

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "dockerfiles": [
     { "tag": "6", "from": "node:6" },
     { "tag": "6-npm6.1", "from": "node:6", "extraInstructions": ["RUN npm install npm@6.1.x", "RUN rm -rf /usr/local/lib/node_modules/npm", "RUN mv node_modules/npm /usr/local/lib/node_modules/npm"] },
-    { "tag": "8", "from": "node:8" }
+    { "tag": "8", "from": "node:8" },
+    { "tag": "10", "from": "node:10" }
   ]
 }

--- a/out/Dockerfile.10
+++ b/out/Dockerfile.10
@@ -1,0 +1,8 @@
+FROM node:10
+ENV NPM_CONFIG_LOGLEVEL warn
+
+WORKDIR /opt/cs-service/
+
+EXPOSE 40404
+
+CMD ["npm", "start"]


### PR DESCRIPTION
As of October, Node 10 is the LTS version. 

[Release Notes](https://nodejs.org/en/blog/release/v10.0.0/)