### PR TITLE
Add Node 12

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
     { "tag": "6", "from": "node:6" },
     { "tag": "6-npm6.1", "from": "node:6", "extraInstructions": ["RUN npm install npm@6.1.x", "RUN rm -rf /usr/local/lib/node_modules/npm", "RUN mv node_modules/npm /usr/local/lib/node_modules/npm"] },
     { "tag": "8", "from": "node:8" },
-    { "tag": "10", "from": "node:10" }
+    { "tag": "10", "from": "node:10" },
+    { "tag": "12", "from": "node:12" }
   ]
 }

--- a/out/Dockerfile.12
+++ b/out/Dockerfile.12
@@ -1,0 +1,8 @@
+FROM node:12
+ENV NPM_CONFIG_LOGLEVEL warn
+
+WORKDIR /opt/cs-service/
+
+EXPOSE 40404
+
+CMD ["npm", "start"]


### PR DESCRIPTION
Node 12 went into LTS today (nodejs/node#29981) with 12.13.0. I confirmed that in Docker Hub, `12` is pointing to `12.13.0`. So I think it's fine for us to include it in our options now?

In my opinion, we should consider having more specific version tags here (12.13.0 rather than just 12), but maybe that's a topic for another time, since it would require more maintenance.